### PR TITLE
Add --strip-local-deps feature

### DIFF
--- a/src/helmet/main.clj
+++ b/src/helmet/main.clj
@@ -17,7 +17,8 @@
     :validate [fs/file? "The metadata yaml must exist"]]
    ["-c" "--command COMMAND"
     :default "helm dep update --skip-refresh"]
-   [nil "--verbose"]])
+   [nil "--verbose"]
+   [nil "--strip-local-deps" "Strip off any local file:// dependencies after building"]])
 
 (defn exit [status msg & rest]
   (do


### PR DESCRIPTION
Helm charts that are packaged up really have no use for file:// dependencies after they are a fully formed
package, since all the of the dependencies will be in the charts folder.  Leaving them can be problematic
if any tooling later tries to use dependency resolution functions, such as `helm dep build` since the file
paths may no longer be relevant on the target system.

This patch adds an optional feature (--strip-local-deps) that will remove any file:// dependencies after
processing is complete.

Signed-off-by: Greg Haskins <greg@manetu.com>